### PR TITLE
Add limit to role's connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ databases.databases[n].citext | If `true` the citext extension is created for th
 databases.roles | A list of database roles and associated properties to create
 databases.roles[n].name | Role name
 databases.roles[n].password | Login password for the role
-databases.max_connections | Maximum number of database connections
+databases.roles[n].conn_limit | Connections limit for the role. If not specified no limit will be set.
+databases.max_connections | Maximum number of database connections.
 databases.log_line_prefix | The postgres `printf` style string that is output at the beginning of each log line. Default: `%m:`
 databases.collect_statement_statistics | Enable the `pg_stat_statements` extension and collect statement execution statistics. Default: `false`
 databases.additional_config | A map of additional key/value pairs to include as extra configuration properties

--- a/jobs/postgres/templates/postgres_start.sh.erb
+++ b/jobs/postgres/templates/postgres_start.sh.erb
@@ -74,6 +74,10 @@ function create_roles() {
       echo "Adding permissions <%= role["permissions"].join(' ') %> for role <%= role["name"] %>..."
       pgexec postgres "ALTER ROLE \"<%= role["name"] %>\" WITH <%= role["permissions"].join(' ') %>"
     <% end %>
+    <% if role["conn_limit"] %>
+      echo "Setting max connections to <%= role["conn_limit"] %> for role <%= role["name"] %>..."
+      pgexec postgres "ALTER ROLE \"<%= role["name"] %>\" WITH CONNECTION LIMIT <%= role["conn_limit"] %>"
+    <% end %>
   <% end %>
 }
 


### PR DESCRIPTION
This PR is to extend PG release capability to permit enforcement of  max connections allowed to a  DB role. If the param is not specified _databases.roles[n].conn_limit_   is not specified it will be unlimited..