### PR TITLE
Make shared_buffers configurable

### DIFF
--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -38,3 +38,5 @@ properties:
     description: "A map of additional key/value pairs to include as extra configuration properties"
   databases.monit_timeout:
     description: "Monit timout in seconds for the postgres job start. If not specified, no timeout statement will be added so that the global monit timeout applies."
+  databases.shared_buffers:
+    description: "The amount of memory the database server uses for shared memory buffers"

--- a/jobs/postgres/templates/postgresql.conf.erb
+++ b/jobs/postgres/templates/postgresql.conf.erb
@@ -19,7 +19,7 @@ max_connections = <%= p("databases.max_connections", 500) %>
 external_pid_file = '/var/vcap/sys/run/postgres/postgres.pid'
 authentication_timeout = 1min
 
-shared_buffers = 128MB
+shared_buffers = <%= p("databases.shared_buffers", 128MB) %>
 temp_buffers = 8MB
 
 max_files_per_process = 1000


### PR DESCRIPTION
When tuning a pg instance most of time also the `shared_buffers` parameter must be changed.
This PR allows the aforementioned value to be changed.