### PR TITLE
Provide basic database link

### DIFF
--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -16,6 +16,10 @@ packages:
   - postgres-9.4.9
   - postgres-9.6.2
 
+provides:
+- name: postgres
+  type: database
+
 properties:
   databases.db_scheme:
     description: "The database scheme"


### PR DESCRIPTION
Allows other releases to get IP address via [BOSH link](https://bosh.io/docs/links.html)

I would also like to see the scheme and port on the link, but I don't think it makes sense while the properties are still namespaced with "database". If properties were changed (e.g. "databases.port" -> "port"), then the link could have more information.