### PR TITLE
default port to 5432

### DIFF
--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -27,6 +27,7 @@ provides:
 properties:
   databases.port:
     description: "The database port"
+    default: 5432
   databases.databases:
     description: "A list of databases and associated properties to create"
     example: |


### PR DESCRIPTION
Seems like a sensible default. This should be backwards-compatible.