### PR TITLE
Allow specifying port and databases for bbr when not using bosh links

### DIFF
--- a/jobs/bbr-postgres-db/spec
+++ b/jobs/bbr-postgres-db/spec
@@ -28,6 +28,12 @@ properties:
   postgres.dbuser:
     default: vcap
     description: "Database user to run backup and restore"
+  postgres.port:
+    default: 5432
+    description: "The database port (not used when using links)"
+  postgres.databases:
+    default: []
+    description: "Databases to backup and restore (not used when using links)"
   postgres.ssl_verify_hostname:
     default: true
     description: "If postgres is configured with a ca, setting this to 'true' changes sslmode to 'verify-full' rather than 'verify-ca'."

--- a/jobs/bbr-postgres-db/templates/config.sh.erb
+++ b/jobs/bbr-postgres-db/templates/config.sh.erb
@@ -1,25 +1,32 @@
 #!/bin/bash -eu
 <%
 dbhost = "localhost"
+sslmode = "prefer"
+port = p("postgres.port")
+databases = p("postgres.databases")
 if_link("database") do |data|
   if p("postgres.dbuser") != "vcap"
     dbhost = data.address
   end
-end
-sslmode = "prefer"
-if link("database").p("databases.tls.ca") != ''
-  if p("postgres.ssl_verify_hostname")
-    sslmode = "verify-full"
-  else
-    sslmode = "verify-ca"
+
+  if data.p("databases.tls.ca") != ''
+     if p("postgres.ssl_verify_hostname")
+        sslmode = "verify-full"
+     else
+        sslmode = "verify-ca"
+     end
   end
+
+  port = data.p("databases.port")
+  databases = data.p("databases.database")
 end
+
  %>
 current_version="11.1"
 JOB_DIR="/var/vcap/jobs/bbr-postgres-db"
 PACKAGE_DIR="/var/vcap/packages/postgres-${current_version}"
-PORT="<%= link("database").p("databases.port") %>"
-DATABASES=(<%= link("database").p("databases.databases", []).map{|d| d["name"]}.join(' ')%>)
+PORT="<%= port %>"
+DATABASES=(<%= databases.map{|d| d["name"]}.join(' ')%>)
 DBHOST=<%= dbhost %>
 
 readonly PGSSLMODE="<%=sslmode%>"

--- a/jobs/bbr-postgres-db/templates/config.sh.erb
+++ b/jobs/bbr-postgres-db/templates/config.sh.erb
@@ -18,7 +18,7 @@ if_link("database") do |data|
   end
 
   port = data.p("databases.port")
-  databases = data.p("databases.database")
+  databases = data.p("databases.databases")
 end
 
  %>

--- a/src/acceptance-tests/deploy/backup_test.go
+++ b/src/acceptance-tests/deploy/backup_test.go
@@ -131,19 +131,29 @@ var _ = Describe("Backup and restore a deployment", func() {
 		}
 
 		Context("BBR job is colocated", func() {
-			BeforeEach(func() {
-				deployHelper.SetOpDefs(helpers.Define_bbr_ops())
+			Context("When using BOSH links", func() {
+				BeforeEach(func() {
+					deployHelper.SetOpDefs(helpers.Define_bbr_ops())
+				})
+
+				It("Fails to restore the database", func() {
+					var err error
+					var cmd *exec.Cmd
+					cmd = exec.Command("bbr", "deployment", "--target", configParams.Bosh.Target, "--username", configParams.Bosh.Username, "--deployment", deployHelper.GetDeploymentName(), "restore", "--artifact-path", fmt.Sprintf("%s/doesnotexist", tempDir))
+					err = cmd.Run()
+					Expect(err).To(HaveOccurred())
+				})
+
+				It("Successfully backup and restore the database", AssertBackupRestoreSuccessful())
 			})
 
-			It("Fails to restore the database", func() {
-				var err error
-				var cmd *exec.Cmd
-				cmd = exec.Command("bbr", "deployment", "--target", configParams.Bosh.Target, "--username", configParams.Bosh.Username, "--deployment", deployHelper.GetDeploymentName(), "restore", "--artifact-path", fmt.Sprintf("%s/doesnotexist", tempDir))
-				err = cmd.Run()
-				Expect(err).To(HaveOccurred())
-			})
+			Context("When not using BOSH links", func() {
+				BeforeEach(func() {
+					deployHelper.SetOpDefs(helpers.Define_bbr_no_links_ops())
+				})
 
-			It("Successfully backup and restore the database", AssertBackupRestoreSuccessful())
+				It("Successfully backup and restore the database", AssertBackupRestoreSuccessful())
+			})
 		})
 
 		Context("BBR job is not colocated", func() {

--- a/src/acceptance-tests/deploy/backup_test.go
+++ b/src/acceptance-tests/deploy/backup_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Backup and restore a deployment", func() {
 
 			Context("When not using BOSH links", func() {
 				BeforeEach(func() {
-					deployHelper.SetOpDefs(helpers.Define_bbr_no_links_ops())
+					deployHelper.SetOpDefs(helpers.Define_bbr_no_link_ops())
 				})
 
 				It("Successfully backup and restore the database", AssertBackupRestoreSuccessful())

--- a/src/acceptance-tests/testing/helpers/op_defs_utilities.go
+++ b/src/acceptance-tests/testing/helpers/op_defs_utilities.go
@@ -37,6 +37,29 @@ func Define_bbr_ops() []OpDefinition {
 	return ops
 }
 
+func Define_bbr_no_link_ops() []OpDefinition {
+	var ops []OpDefinition
+	var value interface{}
+	var path string
+
+	path = "/instance_groups/name=postgres/jobs/-"
+	value = map[interface{}]interface{}{
+		"name":    "bbr-postgres-db",
+		"release": "postgres",
+		"properties": map[interface{}]interface{}{
+			"release_level_backup": true,
+			"postgres": map[interface{}]interface{}{
+				"databases": []interface{}{
+					"sandbox",
+					"sandbox-2",
+				},
+			},
+		},
+	}
+	AddOpDefinition(&ops, "replace", path, value)
+	return ops
+}
+
 func Define_bbr_not_colocated_ops() []OpDefinition {
 	var ops []OpDefinition
 	var value interface{}


### PR DESCRIPTION
Since bosh create-env [still does not support using links](https://github.com/cloudfoundry/bosh-cli/issues/310), I would like to propose the following changes to the bbr job. To allow us to switch to the postgres bbr job, for [bucc](https://github.com/starkandwayne/bucc). 

Original issue: https://github.com/cloudfoundry/postgres-release/issues/26