### PR TITLE
Make sure bbr no link tests actually test without links

### DIFF
--- a/jobs/bbr-postgres-db/spec
+++ b/jobs/bbr-postgres-db/spec
@@ -20,6 +20,7 @@ packages:
 consumes:
 - name: database
   type: database
+  optional: true
 
 properties:
   release_level_backup:

--- a/jobs/bbr-postgres-db/templates/ca_cert.erb
+++ b/jobs/bbr-postgres-db/templates/ca_cert.erb
@@ -1,1 +1,1 @@
-<%=link("database").p("databases.tls.ca")%>
+<%= c = ""; if_link("database") {|d| c = d.p("databases.tls.ca") }; c %>

--- a/jobs/bbr-postgres-db/templates/pgpass.erb
+++ b/jobs/bbr-postgres-db/templates/pgpass.erb
@@ -1,22 +1,21 @@
 <%=
   dbuser = p("postgres.dbuser")
   password = ""
-  link("database").if_p("databases.roles") do |roles|
-    roles.each do |role|
-      if role["name"] == dbuser
-        if role["password"].to_s.empty? and p("postgres.client_certificate") == ""
-          raise "Password or client certificate is required for postgres.dbuser '#{dbuser}'"
+  dbhost = "localhost"
+  port = p("postgres.port")
+  if_link("database") do |data|
+    data.if_p("databases.roles") do |roles|
+      roles.each do |role|
+        if role["name"] == dbuser
+          if role["password"].to_s.empty? and p("postgres.client_certificate") == ""
+            raise "Password or client certificate is required for postgres.dbuser '#{dbuser}'"
+          end
+          password = role["password"].to_s
         end
-        password = role["password"].to_s
       end
     end
+    dbhost = data.address
+    port = data.p("databases.port")
   end
-
-  [
-    link("database").address,
-    link("database").p("databases.port"),
-    '*',
-    dbuser,
-	password,
-  ].join(':')
+  [dbhost,port,'*',dbuser,password].join(':')
  %>

--- a/src/acceptance-tests/testing/helpers/op_defs_utilities.go
+++ b/src/acceptance-tests/testing/helpers/op_defs_utilities.go
@@ -42,6 +42,15 @@ func Define_bbr_no_link_ops() []OpDefinition {
 	var value interface{}
 	var path string
 
+	p := "/instance_groups/name=backup"
+	ops = append(ops, OpDefinition{Type: "remove", Path: &p})
+
+	path = "/instance_groups/name=postgres/jobs/name=postgres/provides"
+	value = map[interface{}]interface{}{
+		"postgres": "nil",
+	}
+	AddOpDefinition(&ops, "replace", path, value)
+
 	path = "/instance_groups/name=postgres/jobs/-"
 	value = map[interface{}]interface{}{
 		"name":    "bbr-postgres-db",
@@ -49,9 +58,10 @@ func Define_bbr_no_link_ops() []OpDefinition {
 		"properties": map[interface{}]interface{}{
 			"release_level_backup": true,
 			"postgres": map[interface{}]interface{}{
-				"databases": []interface{}{
-					"sandbox",
-					"sandbox-2",
+				"port": "5524",
+				"databases": []map[interface{}]interface{}{
+					{"name": "sandbox"},
+					{"name": "sandbox-2"},
 				},
 			},
 		},


### PR DESCRIPTION
This PR is a follow up on #46, apparently links where not fully disabled on my test. So to instances of the `link` helper function where not covered.

Got the tests to run in my environment and have implemented the fix TDD style (made sure the test failed first).

Apologies for the incomplete first PR.