### PR TITLE
Don't throw an error on restore, when table doesn't exist

### DIFF
--- a/jobs/bbr-postgres-db/templates/restore.sh.erb
+++ b/jobs/bbr-postgres-db/templates/restore.sh.erb
@@ -39,6 +39,7 @@ for dbname in ${DATABASES[@]}; do
       --format=custom \
       --dbname="${dbname}" \
       --use-list=${TMP_LIST_FILE} \
+      --if-exists \
       --clean \
       "${BBR_ARTIFACT_FILE_PATH}"
   else

--- a/src/acceptance-tests/deploy/backup_test.go
+++ b/src/acceptance-tests/deploy/backup_test.go
@@ -114,10 +114,7 @@ var _ = Describe("Backup and restore a deployment", func() {
 				By("Restoring the database")
 				cmd = exec.Command("bbr", "deployment", "--target", configParams.Bosh.Target, "--username", configParams.Bosh.Username, "--deployment", deployHelper.GetDeploymentName(), "restore", "--artifact-path", filepath.Dir(files[0]))
 				stdout, stderr, err = helpers.RunCommand(cmd)
-				Expect(err).To(HaveOccurred())
-				// we expect a warning for a single error because restore_0 table
-				// and restore_0_index index were dropped
-				Expect(stderr).To(ContainSubstring("WARNING: errors ignored on restore: 2"))
+				Expect(err).NotTo(HaveOccurred())
 
 				By("Validating that the dropped table has been restored")
 				result, err = db.CheckTableExist("restore_0", pgprops.Databases.Databases[0].Name)


### PR DESCRIPTION
When trying to restore a database (concourse atc) we get a warning about tables which don't exist:
```
pg_restore: [archiver (db)] Error from TOC entry 262; 1259 19454 TABLE pipeline_build_events_1 postgres
pg_restore: [archiver (db)] could not execute query: ERROR:  table "pipeline_build_events_1" does not exist
    Command was: DROP TABLE public.pipeline_build_events_1;
```

This results in a non zero exit code, which makes bbr unhappy:
```
[bbr] 2019/01/21 19:13:37 ERROR - Error restoring bbr-postgres-db on bosh/0.
...
[bbr] 2019/01/21 19:13:49 INFO - Cleaning up...
1 error occurred:
error 1:
Failed to restore: 1 error occurred:
error 1:
Error attempting to run restore for job bbr-postgres-db on bosh/0: pg_restore: connecting to database for restore
...
WARNING: errors ignored on restore: 3 - exit code 1
```

This PR addresses the above issue by using the [`--if-exists`](https://www.postgresql.org/docs/11/app-pgrestore.html) flag.

