### PR TITLE
Fix use_bbr ops file

### DIFF
--- a/templates/operations/use_bbr.yml
+++ b/templates/operations/use_bbr.yml
@@ -2,7 +2,7 @@
   path: /instance_groups/name=postgres/jobs/-
   value:
     name: bbr-postgres-db
-    releases: postgres
+    release: postgres
     consumes:
       database:
         from: postgres-database


### PR DESCRIPTION
Small bugfix: `release` instead of `releases` in `jobs` block