### PR TITLE
Add PostgreSQL13 support

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,3 +10,6 @@ postgres/postgresql-11.15.tar.gz:
   size: 26509534
   object_id: c1ccc6c4-9898-4bae-7914-879cc09af059
   sha: sha256:5f6ef2add1acb93d69012a55c3f276b91f4f0c91aa9a91243d9c5737ed5b5541
+postgres/postgresql-13.10.tar.gz:
+  size: 24191055
+  sha: sha256:00c3896ecb0aba41f05292833100acf2cc67a4125b5db7b76bd0ba55b484af70

--- a/jobs/bbr-postgres-db/templates/config.sh.erb
+++ b/jobs/bbr-postgres-db/templates/config.sh.erb
@@ -22,7 +22,7 @@ if_link("database") do |data|
 end
 
  %>
-current_version="11.15"
+current_version="13.10"
 JOB_DIR="/var/vcap/jobs/bbr-postgres-db"
 PACKAGE_DIR="/var/vcap/packages/postgres-${current_version}"
 PORT="<%= port %>"

--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -29,6 +29,7 @@ packages:
   - postgres-common
   - postgres-9.6.10
   - postgres-11.15
+  - postgres-13.10
 
 provides:
 - name: postgres

--- a/jobs/postgres/templates/pgconfig.sh.erb
+++ b/jobs/postgres/templates/pgconfig.sh.erb
@@ -6,7 +6,7 @@ set -x # if you want tracing disabled, set 'databases.enable_traces: false' in t
 ENABLE_TRACE=0
 # set -x # uncomment it if you want to enable tracing in all control scripts
 <% end %>
-current_version="11.15"
+current_version="13.10"
 pgversion_current="postgres-${current_version}"
 
 JOB_DIR=/var/vcap/jobs/postgres

--- a/packages/postgres-13.10/packaging
+++ b/packages/postgres-13.10/packaging
@@ -1,0 +1,49 @@
+#!/bin/bash -exu
+
+function main() {
+
+  extract_archive
+  compile
+
+}
+
+function extract_archive() {
+
+  echo "Extracting archive..."
+  tar xzf postgres/postgresql-*
+
+}
+
+function compile() {
+
+  pushd postgresql-* > /dev/null
+    if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
+      ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    else
+      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}"  --with-openssl
+    fi
+
+    pushd src/bin/pg_config > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+
+    cp -LR src/include "${BOSH_INSTALL_TARGET}"
+    pushd src/interfaces/libpq > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+
+    pushd src > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+
+    pushd contrib > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+  popd > /dev/null
+}
+
+main

--- a/packages/postgres-13.10/spec
+++ b/packages/postgres-13.10/spec
@@ -1,0 +1,4 @@
+---
+name: postgres-13.10
+files:
+  - postgres/postgresql-13.10.tar.gz


### PR DESCRIPTION
For the blob I downloaded https://github.com/postgres/postgres/archive/refs/tags/REL_13_10.tar.gz

```
wget 'https://github.com/postgres/postgres/archive/refs/tags/REL_13_10.tar.gz'
tar xzf REL_13_10.tar.gz
mv postgres-REL_13_10/ postgresql-13.10
tar czf postgresql-13.10.tar.gz postgresql-13.10
bosh add-blob postgresql-13.10.tar.gz postgres/postgresql-13.10.tar.gz
```

For me compilation worked as well as migrating existing data from a deployment using v44. 

Addresses #61

unfortunately I do not get the acceptance-tests running -.-