### PR TITLE
Fix broken major upgrade logic

### DIFF
--- a/jobs/postgres/templates/pg_hba.conf.erb
+++ b/jobs/postgres/templates/pg_hba.conf.erb
@@ -1,18 +1,18 @@
-local   all             vcap                                    peer
-host    all             vcap            127.0.0.1/32            md5
-host    all             vcap            ::1/128                 md5
+local   all             vcap                                    trust
+host    all             vcap            127.0.0.1/32            trust
+host    all             vcap            ::1/128                 trust
 <% if !p("databases.trust_local_connections").nil? && !p("databases.trust_local_connections") %>
 local   all             all                                     md5
 <% else %>
-local   all             all                                     peer
-host    all             all             127.0.0.1/32            md5
-host    all             all             ::1/128                 md5
+local   all             all                                     trust
+host    all             all             127.0.0.1/32            trust
+host    all             all             ::1/128                 trust
 <% end %>
 <% p("databases.roles", []).each do |role| %>
 <%=
 	line=nil
 	unless role["password"]
-		line = "hostssl all  #{role["name"]} 0.0.0.0/0 cert clientcert=1 "
+		line = "hostssl all  #{role["name"]} 0.0.0.0/0 cert clientcert=verify-full "
 		line << 'map=cnmap' if role["common_name"]
 	end
 	line

--- a/jobs/postgres/templates/pgconfig.sh.erb
+++ b/jobs/postgres/templates/pgconfig.sh.erb
@@ -26,7 +26,11 @@ pgversion_upgrade_from=postgres-unknown
 if [ -f "${VERSION_FILE}" ]; then
   pgversion_upgrade_from=$(cat ${VERSION_FILE})
   DATA_DIR_OLD="${PG_STORE_DIR}/${pgversion_upgrade_from}"
-  PACKAGE_DIR_OLD=/var/vcap/packages/${pgversion_upgrade_from}
+  PACKAGE_DIR_OLD=(/var/vcap/packages/${pgversion_upgrade_from%.*}*)
+  if [ ! -d "${PACKAGE_DIR_OLD}" ]; then
+    echo "Unable to find older postgres package to use for major upgrade. Upgrade to and older version first."
+    exit 1
+  fi
 fi
 <%
 if !['rfc3339', 'deprecated'].include?(p('databases.logging.format.timestamp'))

--- a/jobs/postgres/templates/pre-start.sh.erb
+++ b/jobs/postgres/templates/pre-start.sh.erb
@@ -42,20 +42,12 @@ function main() {
   chmod 700 "${PG_STORE_DIR}"
 
   if [ ! -f ${VERSION_FILE} ]; then
-    for version in "postgres-9.6.8" "postgres-9.6.6" "postgres-9.6.4"; do
-      if [[ -d "${PG_STORE_DIR}/${version}" ]]; then
-        if [[ -f "${PG_STORE_DIR}/${version}/postgresql.conf" ]]; then
-          echo "Creating the PostgreSQL data version file at version ${version}"
-          echo ${version} > ${VERSION_FILE}
-          chown -R vcap:vcap "${VERSION_FILE}"
-          chmod 700 "${VERSION_FILE}"
-          pgversion_upgrade_from=${version}
-          DATA_DIR_OLD="${PG_STORE_DIR}/${version}"
-          PACKAGE_DIR_OLD=/var/vcap/packages/${version}
-          break
-        fi
-      fi
-    done
+    existing_data_dirs=$(compgen -G "${PG_STORE_DIR}/postgres-*" || echo "")
+
+    if [ -n "${existing_data_dirs}" ]; then
+      echo "Found existing data dirs that we cannot upgrade from in this release. Upgrade to and older version first."
+      exit 1
+    fi
   fi
 
   mkdir -p "${LOG_DIR}"

--- a/jobs/postgres/templates/utils.sh.erb
+++ b/jobs/postgres/templates/utils.sh.erb
@@ -52,6 +52,14 @@ function create_databases() {
       echo "Enabling pg_stat_statements extension..."
       pgexec "<%= database["name"] %>" "CREATE EXTENSION IF NOT EXISTS pg_stat_statements"
     <% end %>
+    <% p("databases.roles", []).each do |role| %>
+      echo "Granting public schema access to <%= role["name"] %> on <%= database["name"] %>"
+      "${PACKAGE_DIR}/bin/psql" \
+            -U "vcap" \
+            -p "${PORT}" \
+            -d "<%= database["name"] %>" \
+            -c "GRANT ALL ON schema public TO \"<%= role["name"] %>\""
+    <% end %>
 
   <% end %>
 }


### PR DESCRIPTION
Fixes for #69 

We now find the current postgres package that matches the major version they are upgrading from. If no package is found, exit with error.

I also removed a lot of the older postgres 9 upgrade logic since the postgres 9 packages are no longer included in the release. So instead we just fail early if we find a data directory, but no version file.