### PR TITLE
feat: Add PostgreSQL 16 as new major and used release version

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -36,6 +36,8 @@ jobs:
           trigger: true
         - get: postgres-15-src
           trigger: true
+        - get: postgres-16-src
+          trigger: true
     - task: bump-postgres-11-package
       file: postgres-release/ci/tasks/bump-postgres-packages/task.yml
       image: bosh-cli-registry-image
@@ -67,6 +69,18 @@ jobs:
         postgres-src: postgres-15-src
       params:
         MAJOR_VERSION: 15
+        PRIVATE_YML: |
+          blobstore:
+            options:
+              access_key_id: ((postgres-release-blobstore-user.username))
+              secret_access_key: ((postgres-release-blobstore-user.password))
+    - task: bump-postgres-16-package
+      file: postgres-release/ci/tasks/bump-postgres-packages/task.yml
+      image: bosh-cli-registry-image
+      input_mapping:
+        postgres-src: postgres-16-src
+      params:
+        MAJOR_VERSION: 16
         PRIVATE_YML: |
           blobstore:
             options:
@@ -109,7 +123,7 @@ jobs:
         file: postgres-release/ci/tasks/check-for-updated-blob/task.yml
         image: bosh-cli-registry-image
         params:
-          BLOB: postgresql-15
+          BLOB: postgresql-16
         on_success:
           put: final-release-trigger
 
@@ -130,7 +144,7 @@ jobs:
         file: postgres-release/ci/tasks/check-for-updated-blob/task.yml
         image: bosh-cli-registry-image
         params:
-          BLOB: postgresql-15
+          BLOB: postgresql-16
     - task: create-final-release
       file: postgres-release/ci/tasks/create-final-release/task.yml
       image: bosh-cli-registry-image
@@ -209,6 +223,13 @@ resources:
     source:
       index: "https://ftp.postgresql.org/pub/source/"
       regex: 'href="v(?P<version>15\.[0-9.]+)/"'
+      uri: "https://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.gz"
+
+  - name: postgres-16-src
+    type: http-resource
+    source:
+      index: "https://ftp.postgresql.org/pub/source/"
+      regex: 'href="v(?P<version>16\.[0-9.]+)/"'
       uri: "https://ftp.postgresql.org/pub/source/v{version}/postgresql-{version}.tar.gz"
 
   - name: postgres-release

--- a/jobs/bbr-postgres-db/spec
+++ b/jobs/bbr-postgres-db/spec
@@ -17,6 +17,7 @@ packages:
   - postgres-11
   - postgres-13
   - postgres-15
+  - postgres-16
 
 consumes:
 - name: database

--- a/jobs/bbr-postgres-db/templates/config.sh.erb
+++ b/jobs/bbr-postgres-db/templates/config.sh.erb
@@ -22,7 +22,7 @@ if_link("database") do |data|
 end
 
  %>
-current_version="15.6"
+current_version="16.2"
 JOB_DIR="/var/vcap/jobs/bbr-postgres-db"
 PACKAGE_DIR="/var/vcap/packages/postgres-${current_version%.*}"
 PORT="<%= port %>"

--- a/jobs/postgres/spec
+++ b/jobs/postgres/spec
@@ -30,6 +30,7 @@ packages:
   - postgres-11
   - postgres-13
   - postgres-15
+  - postgres-16
 
 provides:
 - name: postgres

--- a/jobs/postgres/templates/pgconfig.sh.erb
+++ b/jobs/postgres/templates/pgconfig.sh.erb
@@ -6,7 +6,7 @@ set -x # if you want tracing disabled, set 'databases.enable_traces: false' in t
 ENABLE_TRACE=0
 # set -x # uncomment it if you want to enable tracing in all control scripts
 <% end %>
-current_version="15.6"
+current_version="16.2"
 pgversion_current="postgres-${current_version}"
 
 JOB_DIR=/var/vcap/jobs/postgres

--- a/packages/postgres-16/packaging
+++ b/packages/postgres-16/packaging
@@ -17,9 +17,9 @@ function compile() {
 
   pushd postgresql-* > /dev/null
     if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
-      ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl --without-icu
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     else
-      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl --without-icu
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     fi
 
     pushd src/bin/pg_config > /dev/null

--- a/packages/postgres-16/packaging
+++ b/packages/postgres-16/packaging
@@ -1,9 +1,16 @@
 #!/bin/bash -exu
 
 function main() {
-
+  install_requirements
   extract_archive
   compile
+
+}
+
+function install_requirements() {
+
+  echo "Install the requirements..."
+  DEBIAN_FRONTEND=noninteractive apt update && DEBIAN_FRONTEND=noninteractive apt install libicu-dev pkg-config libreadline-dev zlib1g-dev libssl-dev -y
 
 }
 

--- a/packages/postgres-16/packaging
+++ b/packages/postgres-16/packaging
@@ -1,0 +1,49 @@
+#!/bin/bash -exu
+
+function main() {
+
+  extract_archive
+  compile
+
+}
+
+function extract_archive() {
+
+  echo "Extracting archive..."
+  tar xzf postgres/postgresql-*
+
+}
+
+function compile() {
+
+  pushd postgresql-* > /dev/null
+    if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
+      ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    else
+      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}"  --with-openssl
+    fi
+
+    pushd src/bin/pg_config > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+
+    cp -LR src/include "${BOSH_INSTALL_TARGET}"
+    pushd src/interfaces/libpq > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+
+    pushd src > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+
+    pushd contrib > /dev/null
+      make -j$(nproc)
+      make install
+    popd > /dev/null
+  popd > /dev/null
+}
+
+main

--- a/packages/postgres-16/packaging
+++ b/packages/postgres-16/packaging
@@ -1,16 +1,8 @@
 #!/bin/bash -exu
 
 function main() {
-  install_requirements
   extract_archive
   compile
-
-}
-
-function install_requirements() {
-
-  echo "Install the requirements..."
-  DEBIAN_FRONTEND=noninteractive apt update && DEBIAN_FRONTEND=noninteractive apt install libicu-dev pkg-config libreadline-dev zlib1g-dev libssl-dev -y
 
 }
 
@@ -25,9 +17,9 @@ function compile() {
 
   pushd postgresql-* > /dev/null
     if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
-      ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+      ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl --without-icu
     else
-      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}"  --with-openssl
+      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl --without-icu
     fi
 
     pushd src/bin/pg_config > /dev/null

--- a/packages/postgres-16/spec
+++ b/packages/postgres-16/spec
@@ -1,0 +1,4 @@
+---
+name: postgres-16
+files:
+  - postgres/postgresql-16.*.tar.gz


### PR DESCRIPTION
**Description:**
- The PR adds PostgreSQL 16 to the release, adjusts the CI/CD pipeline, and sets it as the new version in use

**TODO:**
- [x] ~Upload the Blobs for PostgreSQL release to the blob store (missing S3 credentials) @beyhan Can you please support me here?~
- [x] Test the dev release

**Follow-up**
- [ ] Make the used version used configurable, handled by #75 