### PR TITLE
Improve Blob Management in PostgreSQL Package Bumping Process

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,7 +81,7 @@ jobs:
               secret_access_key: ((postgres-release-blobstore-user.password))
     - task: bump-postgres-17-package
       file: postgres-release/ci/tasks/bump-postgres-packages/task.yml
-      image: bosh-cli-registry-image
+      image: bosh-integration-image
       input_mapping:
         postgres-src: postgres-17-src
       params:


### PR DESCRIPTION
# Improve Blob Management in PostgreSQL Package Bumping Process

## Changes
- Added safety check for old blob removal during package updates
- Introduced `get_old_blob_path` function to handle blob path retrieval more robustly
- Updated Docker image reference from `bosh-cli-registry-image` to `bosh-integration-image` for PostgreSQL 17 package bumping task

## Problem
Previously, the script would attempt to remove old PostgreSQL blobs unconditionally, which could lead to errors if no previous blob existed (e.g., for new major versions or first-time installations).

## Solution
- Added a new function `get_old_blob_path` that safely retrieves the path of existing PostgreSQL blobs
- Implemented a check to only remove old blobs when they actually exist
- This change makes the blob management process more robust and prevents potential errors during the package bump process

## Testing
- Verified that the script correctly handles:
  - Updates with existing old blobs
  - Updates without existing old blobs
  - First-time package installations