### PR TITLE
feat: Add ARM64 support for yq and PostgreSQL packages

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -50,6 +50,7 @@ jobs:
           params:
             globs:
               - yq_linux_amd64
+              - yq_linux_arm64
               - checksums
               - checksums_hashes_order
     - task: bump-yq-package

--- a/ci/tasks/bump-yq-packages/task.sh
+++ b/ci/tasks/bump-yq-packages/task.sh
@@ -10,30 +10,48 @@ pushd postgres-release
   CURRENT_VERSION=$(cat ../yq-release/version)
 
   sha256_col=$(grep -n "^SHA-256$" ../yq-release/checksums_hashes_order | cut -f1 -d:)
-  expected_sha256=$(awk -v col="$((sha256_col + 1))" '/^yq_linux_amd64[[:space:]]/{print $col}' ../yq-release/checksums)
-  actual_sha256=$(sha256sum ../yq-release/yq_linux_amd64 | awk '{print $1}')
-  if [ "$expected_sha256" != "$actual_sha256" ]; then
-    echo "SHA-256 verification failed for yq_linux_amd64"
-    echo "Expected: $expected_sha256"
-    echo "Actual:   $actual_sha256"
-    exit 1
-  fi
-  echo "SHA-256 verified: $actual_sha256"
-  cp ../yq-release/yq_linux_amd64 ../yq-bin/yq && chmod +x ../yq-bin/yq
 
-  mv ../yq-release/yq_linux_amd64 ../yq-release/postgres-yq-${CURRENT_VERSION}
-  BLOB_PATH=$(ls ../yq-release/postgres-yq-${CURRENT_VERSION})
-  FILENAME=$( basename ${BLOB_PATH} )
-  OLD_BLOB_PATH=$(cat config/blobs.yml  | grep "postgres-yq" | cut -f1 -d:)
-  if ! echo "${CURRENT_BLOBS}" | grep "${FILENAME}" ; then
+  for ARCH in amd64 arm64; do
+    src_file="yq_linux_${ARCH}"
+    blob_name="postgres-yq-${ARCH}-${CURRENT_VERSION}"
+
+    expected_sha256=$(awk -v col="$((sha256_col + 1))" "/^${src_file}[[:space:]]/{print \$col}" ../yq-release/checksums)
+    actual_sha256=$(sha256sum "../yq-release/${src_file}" | awk '{print $1}')
+    if [ "$expected_sha256" != "$actual_sha256" ]; then
+      echo "SHA-256 verification failed for ${src_file}"
+      echo "Expected: $expected_sha256"
+      echo "Actual:   $actual_sha256"
+      exit 1
+    fi
+    echo "SHA-256 verified for ${src_file}: $actual_sha256"
+
+    cp "../yq-release/${src_file}" "../yq-release/${blob_name}"
+
+    if ! echo "${CURRENT_BLOBS}" | grep -q "${blob_name}"; then
+      NEED_COMMIT=true
+      echo "adding ${blob_name}"
+      bosh add-blob --sha2 "../yq-release/${blob_name}" "yq/${blob_name}"
+    fi
+  done
+
+  # Remove any old yq blobs that are not the current amd64 or arm64 blobs
+  while IFS= read -r old_blob; do
+    echo "removing old blob: ${old_blob}"
+    bosh remove-blob "${old_blob}"
     NEED_COMMIT=true
-    echo "adding ${FILENAME}"
-    bosh add-blob --sha2 "${BLOB_PATH}" "yq/${FILENAME}"
-    bosh remove-blob ${OLD_BLOB_PATH}
+  done < <(grep "^yq/" config/blobs.yml \
+    | grep -vF "postgres-yq-amd64-${CURRENT_VERSION}" \
+    | grep -vF "postgres-yq-arm64-${CURRENT_VERSION}" \
+    | cut -f1 -d:)
+
+  if [ "${NEED_COMMIT}" = "true" ]; then
     bosh upload-blobs
   fi
 
-  if ${NEED_COMMIT}; then
+  # Always populate yq-bin from amd64 binary (CI workers are x86_64)
+  cp ../yq-release/yq_linux_amd64 ../yq-bin/yq && chmod +x ../yq-bin/yq
+
+  if [ "${NEED_COMMIT}" = "true" ]; then
     echo "-----> $(date): Creating git commit"
     git config user.name "$GIT_USER_NAME"
     git config user.email "$GIT_USER_EMAIL"

--- a/packages/postgres-15/packaging
+++ b/packages/postgres-15/packaging
@@ -17,10 +17,13 @@ function extract_archive() {
 function compile() {
 
   pushd postgresql-* > /dev/null
-    if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
+    ARCH=$(uname -m)
+    if [[ "$ARCH" == "x86_64" || "$ARCH" == "ppc64le" ]]; then
+      ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    elif [[ "$ARCH" == "aarch64" ]]; then
       ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     else
-      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}"  --with-openssl
+      CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     fi
 
     pushd src/bin/pg_config > /dev/null

--- a/packages/postgres-16/packaging
+++ b/packages/postgres-16/packaging
@@ -16,10 +16,16 @@ function extract_archive() {
 function compile() {
 
   pushd postgresql-* > /dev/null
-    if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
-      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    ARCH=$(uname -m)
+    if [[ "$ARCH" == "x86_64" || "$ARCH" == "ppc64le" ]]; then
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" \
+        ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    elif [[ "$ARCH" == "aarch64" ]]; then
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/aarch64-linux-gnu -licui18n -licuuc -licudata" \
+        ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     else
-      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" \
+        CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     fi
 
     pushd src/bin/pg_config > /dev/null

--- a/packages/postgres-17/packaging
+++ b/packages/postgres-17/packaging
@@ -16,10 +16,16 @@ function extract_archive() {
 function compile() {
 
   pushd postgresql-* > /dev/null
-    if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
-      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    ARCH=$(uname -m)
+    if [[ "$ARCH" == "x86_64" || "$ARCH" == "ppc64le" ]]; then
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" \
+        ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    elif [[ "$ARCH" == "aarch64" ]]; then
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/aarch64-linux-gnu -licui18n -licuuc -licudata" \
+        ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     else
-      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" \
+        CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     fi
 
     pushd src/bin/pg_config > /dev/null

--- a/packages/postgres-18/packaging
+++ b/packages/postgres-18/packaging
@@ -16,10 +16,16 @@ function extract_archive() {
 function compile() {
 
   pushd postgresql-* > /dev/null
-    if [[ "$(uname -a)" =~ "x86_64" || "$(uname -a)" =~ "ppc64le" ]] ; then
-      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    ARCH=$(uname -m)
+    if [[ "$ARCH" == "x86_64" || "$ARCH" == "ppc64le" ]]; then
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" \
+        ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+    elif [[ "$ARCH" == "aarch64" ]]; then
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/aarch64-linux-gnu -licui18n -licuuc -licudata" \
+        ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     else
-      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
+      ICU_CFLAGS=" " ICU_LIBS="-L/usr/lib/x86_64-linux-gnu -licui18n -licuuc -licudata" \
+        CFLAGS=-m32 LDFLAGS=-m32 CXXFLAGS=-m32 ./configure --prefix="${BOSH_INSTALL_TARGET}" --with-openssl
     fi
 
     pushd src/bin/pg_config > /dev/null

--- a/packages/postgres-yq-4/packaging
+++ b/packages/postgres-yq-4/packaging
@@ -2,16 +2,22 @@
 
 function main() {
   install
-
 }
 
 function install() {
+  local arch
+  arch=$(uname -m)
 
   echo "Install yq..."
   mkdir -p "${BOSH_INSTALL_TARGET}/bin"
-  cp -a yq/postgres-yq-4.* "${BOSH_INSTALL_TARGET}/bin/yq"
-  chmod +x "${BOSH_INSTALL_TARGET}/bin/yq"
 
+  case "$arch" in
+    x86_64)  cp yq/postgres-yq-amd64-* "${BOSH_INSTALL_TARGET}/bin/yq" ;;
+    aarch64) cp yq/postgres-yq-arm64-* "${BOSH_INSTALL_TARGET}/bin/yq" ;;
+    *) echo "Unsupported architecture: $arch"; exit 1 ;;
+  esac
+
+  chmod +x "${BOSH_INSTALL_TARGET}/bin/yq"
 }
 
 main

--- a/packages/postgres-yq-4/spec
+++ b/packages/postgres-yq-4/spec
@@ -1,4 +1,5 @@
 ---
 name: postgres-yq-4
 files:
-  - yq/postgres-yq-4.*
+  - yq/postgres-yq-amd64-*
+  - yq/postgres-yq-arm64-*


### PR DESCRIPTION
## Summary

- Store two arch-keyed yq blobs (`postgres-yq-amd64-*`, `postgres-yq-arm64-*`) in the blobstore instead of a single amd64 blob; select the correct one at deploy time via `uname -m`
- Fix `postgres-15/16/17/18` packaging scripts to add an explicit `aarch64` branch, preventing ARM64 VMs from incorrectly falling into the legacy 32-bit (`-m32`) path
- Fix hardcoded ICU library path in `postgres-16/17/18` packaging from `/usr/lib/x86_64-linux-gnu` to `/usr/lib/aarch64-linux-gnu` on ARM64
- Update `bump-yq-packages` CI task to verify SHA-256 and upload blobs for both architectures

## Test Plan

- [ ] Verify `bump-packages` pipeline job runs cleanly and produces two yq blobs in `config/blobs.yml` (`postgres-yq-amd64-*` and `postgres-yq-arm64-*`)
- [ ] Deploy postgres-release to an x86_64 BOSH VM and confirm PostgreSQL and yq work correctly (no regression)
- [ ] Deploy postgres-release to an ARM64 BOSH VM and confirm PostgreSQL and yq install and run correctly

## Depends on
- https://github.com/cloudfoundry/community/pull/1530